### PR TITLE
#56 #16 added working mobile menu opener and closer in the aside. Also freshened up the usage of  `+layout.svelte`. Also added the Header component for the hamburger menu opener

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,0 +1,44 @@
+<header>
+    <a href="#nav-sidebar" class="hamburger-close">
+        <svg xmlns="http://www.w3.org/2000/svg" width="28" height="20" viewBox="0 0 28 20" fill="none">
+            <path d="M2 4H26C27.104 4 28 3.104 28 2C28 0.896 27.104 0 26 0H2C0.896 0 0 0.896 0 2C0 3.104 0.896 4 2 4ZM26 8H2C0.896 8 0 8.896 0 10C0 11.104 0.896 12 2 12H26C27.104 12 28 11.104 28 10C28 8.896 27.104 8 26 8ZM26 16H2C0.896 16 0 16.896 0 18C0 19.104 0.896 20 2 20H26C27.104 20 28 19.104 28 18C28 16.896 27.104 16 26 16Z" fill="#56423D"/>
+        </svg>menu
+    </a>
+    <!-- Nog logo toevoegen -->
+</header>
+<style>
+
+header .hamburger-close{
+    display: flex;
+    color: #0B4989;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 42px;
+    border-radius: 9px;
+    box-sizing: content-box;
+    text-decoration: none;
+    padding: 10px;
+    margin-top: 20px;
+    margin-left: 20px;
+    font-weight: bold;
+    line-height: 1rem;
+    gap: .35rem;
+    transition: 0.3s ease;
+    @media (min-width: 750px){
+        display: none !important;
+    }
+}
+header .hamburger-close svg > *{
+    fill: #0B4989;
+    transition: 0.3s ease;
+}
+header .hamburger-close:hover, header .hamburger-close:focus{
+    background-color: #0B4989;
+    color: white;
+}
+header .hamburger-close:hover svg > *, header .hamburger-close:focus svg > *{
+    fill: white;
+}
+
+</style>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -83,7 +83,7 @@
         transition: 0.5s ease;
         position: fixed;
         top: 0;
-        left: -1px; /* dunno why this is needed xP */
+        left: -1px; /* subpixel bug */
         grid-row: 1 / -1;
     }
     aside .hamburger-open{

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -2,8 +2,13 @@
     let { data } = $props();
 	import { page } from '$app/state';
 </script>
-<aside>
-    <nav class="nav-sidebar" id="nav-sidebar">
+<aside id="nav-sidebar">
+    <a href="#" class="hamburger-open">
+        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22" fill="none">
+            <path d="M20.3331 0.33313C20.715 0.33313 21.0326 0.45985 21.2861 0.71329C21.5395 0.96673 21.6662 1.28438 21.6662 1.66625C21.6662 2.04129 21.5378 2.35724 21.2809 2.61409L12.8848 10.9994L21.2809 19.3846C21.5378 19.6415 21.6662 19.9574 21.6662 20.3325C21.6662 20.7144 21.5395 21.032 21.2861 21.2854C21.0326 21.5389 20.715 21.6656 20.3331 21.6656C19.9581 21.6656 19.6421 21.5372 19.3853 21.2803L11 12.8842L2.6147 21.2803C2.35785 21.5372 2.0419 21.6656 1.66686 21.6656C1.28499 21.6656 0.967341 21.5389 0.713901 21.2854C0.460461 21.032 0.33374 20.7144 0.33374 20.3325C0.33374 19.9574 0.462167 19.6415 0.71902 19.3846L9.11518 10.9994L0.71902 2.61409C0.462167 2.35724 0.33374 2.04129 0.33374 1.66625C0.33374 1.28438 0.460461 0.96673 0.713901 0.71329C0.967341 0.45985 1.28499 0.33313 1.66686 0.33313C2.0419 0.33313 2.35785 0.461557 2.6147 0.71841L11 9.11457L19.3853 0.71841C19.6421 0.461557 19.9581 0.33313 20.3331 0.33313Z" fill="#FCF8F7"/>
+        </svg>Sluit
+    </a>
+    <nav class="nav-sidebar">
         <ul>
             <li class={page.url.pathname === "/" ? "active" : ""}>
                 <a href="/" aria-current={page.url.pathname === `/`}>
@@ -72,14 +77,47 @@
         background-color: lightgray;
         background-color: #137BC0;
         height: 100vh;
-        display: grid;
+        display: flex;
+        flex-direction: column;
         translate: -100% 0;
         transition: 0.5s ease;
         position: fixed;
         top: 0;
-        left: 0;
+        left: -1px; /* dunno why this is needed xP */
+        grid-row: 1 / -1;
     }
-
+    aside .hamburger-open{
+        transition: 0.3s ease;
+		display: flex;
+        line-height: 1rem;
+        gap: .35rem;
+		color: white;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+        width: 42px;
+        border-radius: 9px;
+        box-sizing: content-box;
+        text-decoration: none;
+        position: relative;
+        top: 20px;
+        left: 20px;
+        padding: 10px;
+		@media (min-width: 750px){
+			display: none !important;
+		}
+	}
+    aside .hamburger-open svg > *{
+        fill: white;
+        transition: 0.3s ease;
+    }
+    aside .hamburger-open:hover, aside .hamburger-open:focus{
+        background-color: white;
+        color: #137BC0;
+    }
+    aside .hamburger-open:hover svg > *, aside .hamburger-open:focus svg > *{
+        fill: #137BC0;
+    }
     aside nav{
         padding: 40px 0 0 20px;
     }
@@ -214,6 +252,12 @@
             position: relative;
         }
 
+    }
+    @media (max-width: 750px){
+        aside:target{
+            translate: 0 0;
+            position: absolute;
+        }
     }
 
     

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,3 +4,4 @@
 export { default as Bingocard } from './components/Bingocard.svelte'
 export { default as Sidebar } from './components/Sidebar.svelte'
 export { default as Logo } from './components/Logo.svelte'
+export { default as Header } from './components/Header.svelte'

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
 	import favicon from '$lib/assets/favicon.svg';
+	import { Bingocard, Sidebar, Header } from '$lib'
 	let { children } = $props();
 </script>
 
@@ -11,11 +12,32 @@
 	<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="/css/globals.css">
 </svelte:head>
-{@render children?.()}
 <style>
-	#container{
-		display: grid;
-		grid-template-columns: 350px 1fr;
-		gap: 1rem;
+	@media (min-width: 750px){
+		:global(main){
+			display: inline-block;
+			vertical-align: top;
+		}
 	}
+	@supports (display: grid){
+		@media (min-width: 750px){
+			:global(main){
+				grid-row: 2;
+			}
+			:global(#container){
+				display: grid;
+				grid-template-columns: 350px 1fr;
+				grid-template-rows: max-content 1fr;
+				gap: 1rem;
+			}
+		}
+	}
+
 </style>
+<div id="container">
+    <Sidebar/>
+    <Header/>
+    <main>
+		{@render children?.()}
+    </main>
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,8 @@
 <script>
     let { data } = $props();
 	import { page } from '$app/state';
-    import { Sidebar } from '$lib'
+    import { Sidebar, Header } from '$lib'
 </script>
-<div id="container">
-    <Sidebar/>
-    <main>
+
     <h1>Home</h1>
-    </main>
-</div>
+

--- a/src/routes/behandelingen/+page.svelte
+++ b/src/routes/behandelingen/+page.svelte
@@ -3,9 +3,4 @@
     import { Sidebar } from '$lib'
     import { page } from '$app/state';
 </script>
-<div id="container">
-    <Sidebar/>
-    <main>
-        <h1>Behandelingen pagina</h1>
-    </main>
-</div>
+    <h1>Behandelingen pagina</h1>

--- a/src/routes/bingokaart/+page.svelte
+++ b/src/routes/bingokaart/+page.svelte
@@ -4,10 +4,7 @@
     import { Sidebar } from '$lib'
     import { page } from '$app/state';
 </script>
-<div id="container">
-    <Sidebar/>
-    <main>
+
         <h1>Bingokaart pagina</h1>
         <Bingocard/>
-    </main>
-</div>
+

--- a/static/css/globals.css
+++ b/static/css/globals.css
@@ -4,10 +4,3 @@
     box-sizing: border-box; /* Stupid Flanders */
     font-family: "Inter", sans-serif;
 }
-@media (min-width: 750px){
-    #container{
-        display: grid;
-        grid-template-columns: 320px 1fr;
-        gap: 1rem;
-    }
-}


### PR DESCRIPTION
## What does this change?

A functionality has been added to open the aside with its nav below 750px.
This is fully Progressivly Enhanced as i also implemented code to seperate the aside and the main with `display: inline-block` when grid is not supported,

Also made sure that the main, #container and the new header are in layout.svelte

## How Has This Been Tested?

I tested to open the aside with the button and with spacebar. And made the screen larger than 750px in an open and close state to make sure there are no bugs.

## Images

<img width="401" height="909" alt="Screenshot (577)" src="https://github.com/user-attachments/assets/a2b7243d-1c67-4ca4-a0cf-47cefe197de7" />
<img width="583" height="900" alt="Screenshot (576)" src="https://github.com/user-attachments/assets/3b0cd7b3-f205-4e31-8cfc-7c43130d1ed3" />


## How to review

View this branch locally and make the screen size smaller than 750px, or visit the site on mobile

## After this merge

I need to check the alignment with other components inside main
