### PR TITLE
Added vragenlijst + neutral colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules
 
+## Dylan's test file - weird package.json
+BU.js
+
+
 # Output
 .output
 .vercel

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ SvelteKit is a modern framework built on Svelte that simplifies web development.
 
 #### Sidebar
 
-Contains links to all pages with simple icons and doubles as a mobile menu. On screens ≤750px, it can be toggled open and closed.
+Contains links to all pages with simple icons and doubles as a mobile menu. On screens ≤850px, it can be toggled open and closed.
 
 #### Bingo Card
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,27 @@
 		"": {
 			"name": "herstelkompas",
 			"version": "0.0.1",
+			"dependencies": {
+				"@directus/sdk": "^20.1.0"
+			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^6.0.0",
 				"@sveltejs/kit": "^2.22.0",
 				"@sveltejs/vite-plugin-svelte": "^6.0.0",
 				"svelte": "^5.0.0",
 				"vite": "^7.0.4"
+			}
+		},
+		"node_modules/@directus/sdk": {
+			"version": "20.1.0",
+			"resolved": "https://registry.npmjs.org/@directus/sdk/-/sdk-20.1.0.tgz",
+			"integrity": "sha512-EV2bwfiOXc1QFYAIqfGgyZ7JcKgHF43UVEYivUpMjOLiihI9tpmNfcz/qmOXju7LCZrBmSwTOHMRtOXPdZWiLQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://github.com/directus/directus?sponsor=1"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
 		"@sveltejs/vite-plugin-svelte": "^6.0.0",
 		"svelte": "^5.0.0",
 		"vite": "^7.0.4"
+	},
+	"dependencies": {
+		"@directus/sdk": "^20.1.0"
 	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="nl">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			document.documentElement.classList.add('js-enabled');
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -25,10 +25,14 @@ header .hamburger-close{
     line-height: 1rem;
     gap: .35rem;
     transition: 0.3s ease;
-    @media (min-width: 750px){
-        display: none !important;
-    }
+
 }
+    @media (min-width: 750px){
+        header .hamburger-close{
+            display: none !important;
+        }
+    }
+
 header .hamburger-close svg > *{
     fill: #0B4989;
     transition: 0.3s ease;

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -27,7 +27,7 @@ header .hamburger-close{
     transition: 0.3s ease;
 
 }
-    @media (min-width: 750px){
+    @media (min-width: 850px){
         header .hamburger-close{
             display: none !important;
         }

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -106,7 +106,7 @@
         padding: 10px;
 
 	}
-    @media (min-width: 750px){
+    @media (min-width: 850px){
         aside .hamburger-open{
 			display: none !important;
 		}
@@ -266,14 +266,14 @@
         color: #fff;
         fill: #fff;
     }
-    @media (min-width: 750px){
+    @media (min-width: 850px){
         aside{
             translate: 0 0;
             position: relative;
         }
 
     }
-    @media (max-width: 750px){
+    @media (max-width: 850px){
         aside:target{
             translate: 0 0;
             position: absolute;

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -104,10 +104,13 @@
         top: 20px;
         left: 20px;
         padding: 10px;
-		@media (min-width: 750px){
+
+	}
+    @media (min-width: 750px){
+        aside .hamburger-open{
 			display: none !important;
 		}
-	}
+    }
     aside .hamburger-open svg > *{
         fill: white;
         transition: 0.3s ease;
@@ -128,7 +131,7 @@
         gap: 25px;
         padding: 0;
     }
-    aside nav ul li a{
+    aside nav ul li a {
         color: #fff;
         text-decoration: none;
         font-size: 20px;
@@ -139,65 +142,81 @@
         padding: 10px 0 10px 7px;
         transition: 0.3s ease;
         position: relative;
-        .corners{
-            position: absolute;
-            right: -0.5px;
-            top: 0;
-            height: 100%;
-            width: 1px;
-            transition: 0.3s ease;
-            background: #137BC000;
-            svg{
-                transition: 0.3s ease;
-                > *{
-                    transition: 0.3s ease;
-                }
-            }
-        }
-        &:before{
-            /* background-color: #137BC0; */
-            position: absolute;
-            content: '';
-            width: 15px;
-            height: 15px;
-            right: -.5px;
-            bottom: calc(100% - .5px);
-            border-bottom-right-radius: 0%;
-            transition: 0.3s ease;
-            z-index: 9;
-        }
-        &:after{
-            /* background-color: #137BC0; */
-            position: absolute;
-            content: '';
-            width: 15px;
-            height: 15px;
-            right: -.5px;
-            top: calc(100% - .5px);
-            border-top-right-radius: 0%;
-            transition: 0.3s ease;
-            z-index: 9;
-        }
     }
-    aside nav ul li.active a, aside nav ul li a:hover, aside nav ul li a:focus{
+
+    aside nav ul li a .corners {
+        position: absolute;
+        right: -0.5px;
+        top: 0;
+        height: 100%;
+        width: 1px;
+        transition: 0.3s ease;
+        background: #137BC000;
+    }
+
+    aside nav ul li a .corners svg {
+        transition: 0.3s ease;
+    }
+
+    aside nav ul li a .corners svg > * {
+        transition: 0.3s ease;
+    }
+
+    aside nav ul li a:before {
+        /* background-color: #137BC0; */
+        position: absolute;
+        content: '';
+        width: 15px;
+        height: 15px;
+        right: -.5px;
+        bottom: calc(100% - .5px);
+        border-bottom-right-radius: 0%;
+        transition: 0.3s ease;
+        z-index: 9;
+    }
+
+    aside nav ul li a:after {
+        /* background-color: #137BC0; */
+        position: absolute;
+        content: '';
+        width: 15px;
+        height: 15px;
+        right: -.5px;
+        top: calc(100% - .5px);
+        border-top-right-radius: 0%;
+        transition: 0.3s ease;
+        z-index: 9;
+    }
+
+    aside nav ul li.active a,
+    aside nav ul li a:hover,
+    aside nav ul li a:focus {
         color: #137BC0;
         background-color: #fff;
         border-top-left-radius: 9px;
         border-bottom-left-radius: 9px;
-        
-        .corners{
-            background: white;
-        }
-        &:before{
-            /* border-bottom-right-radius: 100%; */
-            background-image: radial-gradient(farthest-side circle at 0% 0%, #0000 calc(100% - .5px), white 100%);
-        }
-        &:after{
-            /* border-top-right-radius: 100%; */
-            background-image: radial-gradient(farthest-side circle at 0% 100%, #0000 calc(100% - .5px), white 100%);
-        }
-        
     }
+
+    aside nav ul li.active a .corners,
+    aside nav ul li a:hover .corners,
+    aside nav ul li a:focus .corners {
+        background: white;
+    }
+
+    aside nav ul li.active a:before,
+    aside nav ul li a:hover:before,
+    aside nav ul li a:focus:before {
+        /* border-bottom-right-radius: 100%; */
+        background-image: radial-gradient(farthest-side circle at 0% 0%, #0000 calc(100% - .5px), white 100%);
+    }
+
+    aside nav ul li.active a:after,
+    aside nav ul li a:hover:after,
+    aside nav ul li a:focus:after {
+        /* border-top-right-radius: 100%; */
+        background-image: radial-gradient(farthest-side circle at 0% 100%, #0000 calc(100% - .5px), white 100%);
+    }
+
     aside nav ul li a svg.fill-fix, aside nav ul li a svg.fill-fix > *, aside nav ul li a svg.fill-fix, aside nav ul li a svg.fill-fix, aside nav ul li a svg.fill-fix > *, aside nav ul li a svg.fill-fix > *{
         fill: #fff;
     }

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -85,6 +85,7 @@
         top: 0;
         left: -1px; /* subpixel bug */
         grid-row: 1 / -1;
+        z-index: 1;
     }
     aside .hamburger-open{
         transition: 0.3s ease;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,10 @@
 			vertical-align: top;
 		}
 	}
+	:global(#container){
+		max-height: 100vh;
+		overflow: hidden;
+	}
 	@supports (display: grid){
 		@media (min-width: 750px){
 			:global(main){

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
 		@media (min-width: 750px){
 			:global(main){
 				grid-row: 2;
+				position: relative;
 			}
 			:global(#container){
 				display: grid;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 	<link rel="stylesheet" href="/css/globals.css">
 </svelte:head>
 <style>
-	@media (min-width: 750px){
+	@media (min-width: 850px){
 		:global(main){
 			display: inline-block;
 			vertical-align: top;
@@ -24,7 +24,7 @@
 		overflow: hidden;
 	}
 	@supports (display: grid){
-		@media (min-width: 750px){
+		@media (min-width: 850px){
 			:global(main){
 				grid-row: 2;
 				position: relative;

--- a/src/routes/vragenlijst/+page.server.js
+++ b/src/routes/vragenlijst/+page.server.js
@@ -1,0 +1,124 @@
+/// AUTHENTICATIE
+
+import { createDirectus, authentication } from '@directus/sdk';
+import { DIRECTUS_EMAIL, DIRECTUS_PASSWORD, DIRECTUS_URL } from '$env/static/private';
+const client = createDirectus(DIRECTUS_URL).with(authentication());
+const token = await client.login({
+    email: DIRECTUS_EMAIL,
+    password: DIRECTUS_PASSWORD
+});
+
+////
+
+export async function load({}){
+    const vragenReponse = await fetch('https://fdnd-agency.directus.app/items/vraag') // meest recent
+    const vragenReponseData = await vragenReponse.json()
+    let vragen = vragenReponseData.data
+    return { vragen };
+}
+
+
+export const actions = {
+    default: async ({ request }) => {
+        // Maak een nieuw array aan voor een nieuwe antwoorden op de vragenlijst.
+        let newQuestionsarray = [];
+
+        // haal alle gecheckte veldfen op van het formulier
+        const data = await request.formData();
+        // let checkedFields = data.getAll('bingocard-field');
+
+        const vragenReponse = await fetch('https://fdnd-agency.directus.app/items/vraag')
+        const vragenReponseData = await vragenReponse.json()
+        let vragen = vragenReponseData.data
+        let vragenAmount = vragen.length;
+        vragen.forEach( (vraag, i) =>{
+            console.log('q-'+ (i + 1))
+            let curQuestionValue = data.getAll('q-'+ (i + 1));
+            newQuestionsarray.push({vraag: vraag.vraag, answer: curQuestionValue})
+        })
+        console.table(newQuestionsarray)
+
+        const behandelingenReponse = await fetch('https://fdnd-agency.directus.app/items/behandeling?limit=1&sort=-datum') // haal meest recente behandeling op. Als er meer op een datum zijn, dan de laatste
+        const behandelingenReponseData = await behandelingenReponse.json()
+        let behandelingen = behandelingenReponseData.data[0]
+        console.log(behandelingen)
+        // let lastbingokaart = behandelingen.bingokaart
+
+        // // loop door activiteiten van huidige bingokaart. Is activiteit ook aanwezig in de gecheckte velden, voeg dan een object toe waar de waarde checked true is, anders een met de waarde checked false.
+        // lastbingokaart.forEach(bingosquare => {
+        //     if(checkedFields.includes(bingosquare.activiteit)){
+        //         newCardState.push({activiteit: bingosquare.activiteit,checked: true })
+        //     }else{
+        //        newCardState.push({activiteit: bingosquare.activiteit,checked: false })
+        //     }
+        // });
+        // // Thanks, chat, voor het genereren van de huidige datum en daarvan het begin en het eind van de dag, van jouw eigen tijdzone
+        //     const today = new Date();
+
+        //     const start = new Date(
+        //         today.getFullYear(),
+        //         today.getMonth(),
+        //         today.getDate(),
+        //         0, 0, 0, 0
+        //     );
+
+        //     const end = new Date(
+        //         today.getFullYear(),
+        //         today.getMonth(),
+        //         today.getDate(),
+        //         23, 59, 59, 999
+        //     );
+        //     function toLocalISOString(date) {
+        //         const pad = (n) => n.toString().padStart(2, '0');
+        //         return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+        //     }
+
+        //     const startString = toLocalISOString(start);
+        //     const endString = toLocalISOString(end);
+        // //
+
+        // // zoek naar de meest recente behandeling van vandaag
+        // const url = `https://fdnd-agency.directus.app/items/behandeling?filter[datum][_between]=${startString},${endString}&limit=1&sort=-datum`;
+        // const todayBehandeling =  await fetch(url)
+        // const todayBehandelingReponseData = await todayBehandeling.json()
+        // let todayBehandelingData = todayBehandelingReponseData.data;
+
+        // // als er vandaag geen behandeling was, posten, anders pas de bingokaart aan van de meest recente behandeling
+        // if(!todayBehandelingReponseData.data || todayBehandelingData.length == 0){
+        //     const todaydatetime = today.toISOString().slice(0, 19);
+        //     /// POSTEN
+        //     const recordResponse = await fetch('https://fdnd-agency.directus.app/items/behandeling', {
+        //         method: 'POST',
+        //         headers: {
+        //             'Content-Type': 'application/json',
+        //             'Authorization': token.access_token
+        //         },
+        //         body: JSON.stringify({
+        //             beschrijving: "Geen beschrijving",
+        //             datum: todaydatetime,
+        //             bingokaart: newCardState
+        //         }),
+        //     });
+        // }
+        // else{
+        //     // PATCH de bingokaart
+        //     const recordId = todayBehandelingData[0].id;
+        //     const patchRes = await fetch(`https://fdnd-agency.directus.app/items/behandeling/${recordId}`, {
+        //         method: 'PATCH',
+        //         headers: {
+        //         'Content-Type': 'application/json',
+        //         'Authorization': token.access_token
+        //         },
+        //         body: JSON.stringify({
+        //             bingokaart: newCardState 
+        //         })
+        //     });
+        //     const patchResult = await patchRes.json();
+        // }
+        // return {
+        //     success: true,
+        //     message: "Yay!!",
+        //     newCardState
+        // };
+    }
+};

--- a/src/routes/vragenlijst/+page.server.js
+++ b/src/routes/vragenlijst/+page.server.js
@@ -14,7 +14,14 @@ export async function load({}){
     const vragenReponse = await fetch('https://fdnd-agency.directus.app/items/vraag') // meest recent
     const vragenReponseData = await vragenReponse.json()
     let vragen = vragenReponseData.data
-    return { vragen };
+    let agreementsScales = [
+        { text: "Zeer mee oneens" },
+        { text: "Oneens" },
+        { text: "Neutraal" },
+        { text: "Eens" },
+        { text: "Zeer mee eens" },
+    ];
+    return { vragen, agreementsScales };
 }
 
 

--- a/src/routes/vragenlijst/+page.server.js
+++ b/src/routes/vragenlijst/+page.server.js
@@ -32,100 +32,111 @@ export const actions = {
 
         // haal alle gecheckte veldfen op van het formulier
         const data = await request.formData();
-        // let checkedFields = data.getAll('bingocard-field');
-
         const vragenReponse = await fetch('https://fdnd-agency.directus.app/items/vraag')
         const vragenReponseData = await vragenReponse.json()
         let vragen = vragenReponseData.data
         let vragenAmount = vragen.length;
         vragen.forEach( (vraag, i) =>{
-            console.log('q-'+ (i + 1))
             let curQuestionValue = data.getAll('q-'+ (i + 1));
             newQuestionsarray.push({vraag: vraag.vraag, answer: curQuestionValue})
         })
-        console.table(newQuestionsarray)
+            const today = new Date();
 
-        const behandelingenReponse = await fetch('https://fdnd-agency.directus.app/items/behandeling?limit=1&sort=-datum') // haal meest recente behandeling op. Als er meer op een datum zijn, dan de laatste
-        const behandelingenReponseData = await behandelingenReponse.json()
-        let behandelingen = behandelingenReponseData.data[0]
-        console.log(behandelingen)
-        // let lastbingokaart = behandelingen.bingokaart
+            const start = new Date(
+                today.getFullYear(),
+                today.getMonth(),
+                today.getDate(),
+                0, 0, 0, 0
+            );
 
-        // // loop door activiteiten van huidige bingokaart. Is activiteit ook aanwezig in de gecheckte velden, voeg dan een object toe waar de waarde checked true is, anders een met de waarde checked false.
-        // lastbingokaart.forEach(bingosquare => {
-        //     if(checkedFields.includes(bingosquare.activiteit)){
-        //         newCardState.push({activiteit: bingosquare.activiteit,checked: true })
-        //     }else{
-        //        newCardState.push({activiteit: bingosquare.activiteit,checked: false })
-        //     }
-        // });
-        // // Thanks, chat, voor het genereren van de huidige datum en daarvan het begin en het eind van de dag, van jouw eigen tijdzone
-        //     const today = new Date();
+            const end = new Date(
+                today.getFullYear(),
+                today.getMonth(),
+                today.getDate(),
+                23, 59, 59, 999
+            );
+            function toLocalISOString(date) {
+                const pad = (n) => n.toString().padStart(2, '0');
+                return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+            }
 
-        //     const start = new Date(
-        //         today.getFullYear(),
-        //         today.getMonth(),
-        //         today.getDate(),
-        //         0, 0, 0, 0
-        //     );
+            const startString = toLocalISOString(start);
+            const endString = toLocalISOString(end);
+        //
 
-        //     const end = new Date(
-        //         today.getFullYear(),
-        //         today.getMonth(),
-        //         today.getDate(),
-        //         23, 59, 59, 999
-        //     );
-        //     function toLocalISOString(date) {
-        //         const pad = (n) => n.toString().padStart(2, '0');
-        //         return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-        //     }
-
-        //     const startString = toLocalISOString(start);
-        //     const endString = toLocalISOString(end);
-        // //
-
-        // // zoek naar de meest recente behandeling van vandaag
-        // const url = `https://fdnd-agency.directus.app/items/behandeling?filter[datum][_between]=${startString},${endString}&limit=1&sort=-datum`;
-        // const todayBehandeling =  await fetch(url)
-        // const todayBehandelingReponseData = await todayBehandeling.json()
-        // let todayBehandelingData = todayBehandelingReponseData.data;
-
-        // // als er vandaag geen behandeling was, posten, anders pas de bingokaart aan van de meest recente behandeling
-        // if(!todayBehandelingReponseData.data || todayBehandelingData.length == 0){
-        //     const todaydatetime = today.toISOString().slice(0, 19);
-        //     /// POSTEN
-        //     const recordResponse = await fetch('https://fdnd-agency.directus.app/items/behandeling', {
-        //         method: 'POST',
-        //         headers: {
-        //             'Content-Type': 'application/json',
-        //             'Authorization': token.access_token
-        //         },
-        //         body: JSON.stringify({
-        //             beschrijving: "Geen beschrijving",
-        //             datum: todaydatetime,
-        //             bingokaart: newCardState
-        //         }),
-        //     });
+        // zoek naar de meest recente behandeling van vandaag
+        const url = `https://fdnd-agency.directus.app/items/behandeling?filter[datum][_between]=${startString},${endString}&limit=1&sort=-datum`;
+        const todayBehandeling =  await fetch(url)
+        const todayBehandelingReponseData = await todayBehandeling.json()
+        let todayBehandelingData = todayBehandelingReponseData.data;
+        let lastbingokaart;
+        console.log(todayBehandelingReponseData.data);
+        // if(!todayBehandelingData.bingokaart){
+        //     const lastBingoCardurl = `https://fdnd-agency.directus.app/items/behandeling?filter[bingokaart][_nnull]=true&limit=1&sort=-datum`;
+        //     const lastBingoCardFetch =  await fetch(lastBingoCardurl)
+        //     const lastBingoCardFetchJson = await lastBingoCardFetch.json()
+        //     const lastBingoCardFetchData = lastBingoCardFetchJson.data;
+        //     lastbingokaart = lastBingoCardFetchData[0].bingokaart;
         // }
         // else{
-        //     // PATCH de bingokaart
-        //     const recordId = todayBehandelingData[0].id;
-        //     const patchRes = await fetch(`https://fdnd-agency.directus.app/items/behandeling/${recordId}`, {
-        //         method: 'PATCH',
-        //         headers: {
-        //         'Content-Type': 'application/json',
-        //         'Authorization': token.access_token
-        //         },
-        //         body: JSON.stringify({
-        //             bingokaart: newCardState 
-        //         })
-        //     });
-        //     const patchResult = await patchRes.json();
+        //     lastbingokaart = todayBehandelingData[0].bingokaart;
         // }
-        // return {
-        //     success: true,
-        //     message: "Yay!!",
-        //     newCardState
-        // };
+
+        // als er vandaag geen behandeling was, posten, anders pas de vragenlijst aan van de meest recente behandeling
+        if(!todayBehandelingReponseData.data || todayBehandelingData.length == 0){
+            const lastBingoCardurl = `https://fdnd-agency.directus.app/items/behandeling?filter[bingokaart][_nnull]=true&limit=1&sort=-datum`;
+            const lastBingoCardFetch =  await fetch(lastBingoCardurl)
+            const lastBingoCardFetchJson = await lastBingoCardFetch.json()
+            const lastBingoCardFetchData = lastBingoCardFetchJson.data;
+            lastbingokaart = lastBingoCardFetchData[0].bingokaart;
+            console.log(lastbingokaart)
+            const todaydatetime = today.toISOString().slice(0, 19);
+            /// POSTEN
+            const recordResponse = await fetch('https://fdnd-agency.directus.app/items/behandeling', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': token.access_token
+                },
+                body: JSON.stringify({
+                    beschrijving: "Geen beschrijving",
+                    datum: todaydatetime,
+                    bingokaart: lastbingokaart,
+                    vragenlijst: newQuestionsarray
+                }),
+            });
+        }
+        else{
+            // PATCH de vragenlijst
+            const recordId = todayBehandelingData[0].id;
+            // If for some reason a treatment has no bingocard and no questions answers
+            if(!todayBehandelingData.bingokaart){
+                const lastBingoCardurl = `https://fdnd-agency.directus.app/items/behandeling?filter[bingokaart][_nnull]=true&limit=1&sort=-datum`;
+                const lastBingoCardFetch =  await fetch(lastBingoCardurl)
+                const lastBingoCardFetchJson = await lastBingoCardFetch.json()
+                const lastBingoCardFetchData = lastBingoCardFetchJson.data;
+                lastbingokaart = lastBingoCardFetchData[0].bingokaart;
+            }
+            else{
+                lastbingokaart = todayBehandelingData[0].bingokaart;
+            }
+            ///
+            const patchRes = await fetch(`https://fdnd-agency.directus.app/items/behandeling/${recordId}`, {
+                method: 'PATCH',
+                headers: {
+                'Content-Type': 'application/json',
+                'Authorization': token.access_token
+                },
+                body: JSON.stringify({
+                    bingokaart: lastbingokaart,
+                    vragenlijst: newQuestionsarray 
+                })
+            });
+            const patchResult = await patchRes.json();
+        }
+        return {
+            success: true,
+            message: "Yay!!",
+        };
     }
 };

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -23,6 +23,7 @@
             // add left
             const prevBtn = document.createElement("button");
             prevBtn.textContent = "Vorige";
+            prevBtn.setAttribute("aria-hidden", "true");
             prevBtn.tabIndex = -1;
             prevBtn.classList.add("btn-prev");
             prevBtn.classList.add("btn-nav");
@@ -34,6 +35,7 @@
             //right
             const nextBtn = document.createElement("button");
             nextBtn.textContent = "Volgende";
+            nextBtn.setAttribute("aria-hidden", "true");
             nextBtn.tabIndex = -1;
             nextBtn.classList.add("btn-next");
             nextBtn.classList.add("btn-nav");

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -120,6 +120,7 @@
                 }
             });
         });
+
     });
     //prev question button click
     function prevQuestion(e) {
@@ -205,6 +206,7 @@
                                     id="q-{i + 1}-a-{j + 1}"
                                     name="q-{i + 1}"
                                     value={agreementsScale.text}
+                                    checked={j === 2}
                                     required={j === 0}
                                     oninvalid={j === 0
                                         ? (e) => {
@@ -299,7 +301,7 @@
     }
     @media (prefers-reduced-motion: no-preference) {
 
-        :global(.animation--slide-in){
+        :global(.js-enabled .animation--slide-in){
             legend{
                 animation: .5s slide-in ease-in;
             }

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -268,9 +268,7 @@
         flex-direction: column;
         align-items: center;
     }
-    legend {
-        height: 72px;
-    }
+
     form {
         width: 100%;
         display: flex;
@@ -299,7 +297,8 @@
         border: none;
         margin: 0;
         transition: 1.25s ease;
-        
+        display: flex;
+        justify-content: start;
     }
     @media (prefers-reduced-motion: no-preference) {
 
@@ -428,7 +427,13 @@
     flex: 1;
     opacity: 0;
     text-align: center;
+            justify-content: center;
 }
+:global(html.js-enabled)  legend {
+        height: 125px;
+        display: flex;
+        align-items: end;
+    }
 
 :global(html.js-enabled) section fieldset:first-child {
     opacity: 1;

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -256,8 +256,8 @@
         opacity: 0;
         transform: translateY(5px);
         transition:
-            opacity 1s,
-            transform 1s;
+            opacity .5s,
+            transform .5s;
     }
     section {
         display: flex;
@@ -297,11 +297,14 @@
         transition: 1.25s ease;
         
     }
-    :global(.animation--slide-in){
+    @media (prefers-reduced-motion: no-preference) {
+
+        :global(.animation--slide-in){
             legend{
                 animation: .5s slide-in ease-in;
             }
         }
+    }
 
     legend {
         font-weight: 600;
@@ -483,16 +486,18 @@
             position: absolute;
             translate: -50% -50%;
             opacity: 1;
-            transition: 2s ease;
+            transition: .5s ease;
             justify-content: center;
             display: flex;
             width: 100%;
             max-width: 310px;
             flex-wrap: wrap;
             row-gap: 10px;
-            @starting-style {
-                opacity: 0;
-                top: 550px;
+            @media (prefers-reduced-motion: no-preference) {
+                @starting-style {
+                    opacity: 0;
+                    top: 550px;
+                }
             }
         }
         :global(button.btn-nav) {

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -1,61 +1,197 @@
 <script>
     let { data } = $props();
-    let vragenlijst = data.vragen
+    let vragenlijst = data.vragen;
     let agreementsScales = [
-        {"text": "Zeer mee oneens"},
-        {"text": "Oneens"},
-        {"text": "Neutraal"},
-        {"text": "Eens"},
-        {"text": "Zeer mee eens"}
-    ]
+        { text: "Zeer mee oneens" },
+        { text: "Oneens" },
+        { text: "Neutraal" },
+        { text: "Eens" },
+        { text: "Zeer mee eens" },
+    ];
 </script>
 
 <section class="no-js">
+    <header class="page-header">
+        <h1>Vragenlijst</h1>
+        <p class="subtitle">Hoe heb je vandaag ervaren?</p>
+    </header>
     <form method="POST">
-        {#each vragenlijst as vraag, i }
+        {#each vragenlijst as vraag, i}
             <fieldset>
                 <legend>{vraag.vraag}</legend>
-                <div>
-                    {#each agreementsScales as agreementsScale,j}
-                        <input
-                        type="radio"
-                        id="q-{i + 1}-a-{j + 1}"
-                        name="q-{i + 1}"
-                        value="{agreementsScale.text}"
-                        required={j === 0}
-                        oninvalid={j === 0 ? (e) => {
-                            const radios = document.querySelectorAll('input[name="q-'+i + 1+']');
-                            radios.forEach(r => r.setCustomValidity('Kies een waarde'));
-                        } : undefined}
-                        oninput={(e) => {
-                            const radios = document.querySelectorAll('input[name="q-'+i + 1+']');
-                            radios.forEach(r => r.setCustomValidity(''));
-                        }}
-                        />
-                        <!-- Custom bericht als veld niet ingevuld is-->
-                        <!-- https://www.w3schools.com/jsref/event_oninvalid.asp -->
-                        <!-- https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity -->
-                        <label for="q-{i + 1}-a-{j + 1}">{agreementsScale.text}</label>
+                <div class="answers-wrapper">
+                    {#each agreementsScales as agreementsScale, j}
+                        <div class="input-wrapper">
+                            <input
+                                data-num={j + 1}
+                                type="radio"
+                                id="q-{i + 1}-a-{j + 1}"
+                                name="q-{i + 1}"
+                                value={agreementsScale.text}
+                                required={j === 0}
+                                oninvalid={j === 0
+                                    ? (e) => {
+                                          const radios =
+                                              document.querySelectorAll(
+                                                  'input[name="q-' +
+                                                      i +
+                                                      1 +
+                                                      "]",
+                                              );
+                                          radios.forEach((r) =>
+                                              r.setCustomValidity(
+                                                  "Kies een waarde",
+                                              ),
+                                          );
+                                      }
+                                    : undefined}
+                                oninput={(e) => {
+                                    const radios = document.querySelectorAll(
+                                        'input[name="q-' + i + 1 + "]",
+                                    );
+                                    radios.forEach((r) =>
+                                        r.setCustomValidity(""),
+                                    );
+                                }}
+                            />
+                            <!-- Custom bericht als veld niet ingevuld is-->
+                            <!-- https://www.w3schools.com/jsref/event_oninvalid.asp -->
+                            <!-- https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity -->
+                            <label for="q-{i + 1}-a-{j + 1}"
+                                >{agreementsScale.text}</label
+                            >
+                        </div>
                     {/each}
                 </div>
             </fieldset>
         {/each}
-           
-        <div id="formControl">
-            <input type="submit" value="Submit">
-        </div>
 
+        <div id="formControl">
+            <input type="submit" value="Submit" />
+        </div>
     </form>
 </section>
-<style>
-    fieldset {
-  padding: 0.5rem 1rem;
-  margin: 0;
-}
 
-legend {
-  padding: 0 0.25rem;
-  font-size: 1rem;
-  font-weight: bold;
-}
+<style>
+    section {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+    form {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+        max-height: calc(100vh - 150px);
+
+        overflow-y: auto;
+        padding-bottom: 3rem;
+    }
+    @media (min-width: 750px){
+        form{
+        max-height: calc(100vh - 90px);
+        }
+    }
+    fieldset {
+padding: 0 1rem
+16px
+;
+        border: none;
+        margin: 0;
+    }
+
+    legend {
+        font-weight: 600;
+        font-size: var(--text-size-xl);
+        color: var(--color-neutral);
+        max-width: 48rem;
+    }
+    main {
+        font-family: var(--font-regular);
+        background-color: var(--color-white);
+    }
+    header {
+        align-self: start;
+    }
+    header h1 {
+        color: var(--primary-color-dark);
+        font-family: var(--font-semibold);
+        font-size: var(--text-size-xl);
+        margin-bottom: 0.25rem;
+        margin-left: 1rem;
+    }
+
+    header .subtitle {
+        color: var(--primary-color-dark);
+        font-size: var(--text-size-sm);
+        margin-bottom: 1rem;
+        margin-left: 1rem;
+    }
+    input[type="radio"] {
+        width: 64px;
+        height: 64px;
+        border-radius: 10px;
+        background-color: #e8ebf2;
+        appearance: none;
+        border: 2px solid var(--color-neutral);
+        position: relative;
+        transition: 0.3s ease-in;
+        cursor: pointer;
+        &:before {
+            content: attr(data-num);
+            font-size: var(--text-size-lg);
+            font-weight: 800;
+            color: var(--color-neutral);
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            translate: -50% -50%;
+            transition: 0.3s ease-in;
+        }
+    }
+    input[type="radio"]:checked,input[type="radio"]:focus-visible, .input-wrapper:hover input[type="radio"]{
+        width: 64px;
+        height: 64px;
+        border-radius: 10px;
+        background-color: var(--color-neutral);
+        appearance: none;
+        border: 2px solid var(--color-neutral);
+        &:before {
+            color: #e8ebf2;
+        }
+    }
+    input[type="radio"] + label{
+        cursor: pointer;
+        font-weight: 600;
+        color: var(--color-neutral);
+    }
+    input[type="submit"]{
+        cursor: pointer;
+        padding: 8px 30px;
+        background-color: #54689C;
+        color: #DEF0FC;
+        border: 2px solid #54689C;
+        border-radius: 10px;
+        margin-left: 1rem;
+        font-size: 18px;
+        font-weight: bold;
+    }
+    input[type="submit"]:hover,input[type="submit"]:focus-visible{
+        background-color: #e8ebf2;
+        color: var(--color-neutral);
+    }
+    .answers-wrapper {
+        display: flex;
+        gap: 1rem;
+        flex-direction: column;
+        margin-top: 1rem;
+    }
+    .input-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        width: fit-content;
+        cursor: pointer;
+    }
 </style>

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -1,0 +1,61 @@
+<script>
+    let { data } = $props();
+    let vragenlijst = data.vragen
+    let agreementsScales = [
+        {"text": "Zeer mee oneens"},
+        {"text": "Oneens"},
+        {"text": "Neutraal"},
+        {"text": "Eens"},
+        {"text": "Zeer mee eens"}
+    ]
+</script>
+
+<section class="no-js">
+    <form method="POST">
+        {#each vragenlijst as vraag, i }
+            <fieldset>
+                <legend>{vraag.vraag}</legend>
+                <div>
+                    {#each agreementsScales as agreementsScale,j}
+                        <input
+                        type="radio"
+                        id="q-{i + 1}-a-{j + 1}"
+                        name="q-{i + 1}"
+                        value="{agreementsScale.text}"
+                        required={j === 0}
+                        oninvalid={j === 0 ? (e) => {
+                            const radios = document.querySelectorAll('input[name="q-'+i + 1+']');
+                            radios.forEach(r => r.setCustomValidity('Kies een waarde'));
+                        } : undefined}
+                        oninput={(e) => {
+                            const radios = document.querySelectorAll('input[name="q-'+i + 1+']');
+                            radios.forEach(r => r.setCustomValidity(''));
+                        }}
+                        />
+                        <!-- Custom bericht als veld niet ingevuld is-->
+                        <!-- https://www.w3schools.com/jsref/event_oninvalid.asp -->
+                        <!-- https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity -->
+                        <label for="q-{i + 1}-a-{j + 1}">{agreementsScale.text}</label>
+                    {/each}
+                </div>
+            </fieldset>
+        {/each}
+           
+        <div id="formControl">
+            <input type="submit" value="Submit">
+        </div>
+
+    </form>
+</section>
+<style>
+    fieldset {
+  padding: 0.5rem 1rem;
+  margin: 0;
+}
+
+legend {
+  padding: 0 0.25rem;
+  font-size: 1rem;
+  font-weight: bold;
+}
+</style>

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -303,10 +303,8 @@
     }
     @media (prefers-reduced-motion: no-preference) {
 
-        :global(.js-enabled .animation--slide-in){
-            legend{
-                animation: .5s slide-in ease-in;
-            }
+        :global(.js-enabled .animation--slide-in) legend{
+            animation: .5s slide-in ease-in;
         }
     }
 
@@ -315,6 +313,7 @@
         font-size: var(--text-size-xl);
         color: var(--color-neutral);
         max-width: 48rem;
+        margin: 0 auto;
     }
     main {
         font-family: var(--font-regular);
@@ -347,31 +346,32 @@
         position: relative;
         transition: 0.3s ease-in;
         cursor: pointer;
-        &:before {
-            content: attr(data-num);
-            font-size: var(--text-size-lg);
-            font-weight: 800;
-            color: var(--color-neutral);
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            translate: -50% -50%;
-            transition: 0.3s ease-in;
-        }
+    }
+    input[type="radio"]:before {
+        content: attr(data-num);
+        font-size: var(--text-size-lg);
+        font-weight: 800;
+        color: var(--color-neutral);
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        translate: -50% -50%;
+        transition: 0.3s ease-in;
     }
     input[type="radio"]:checked,
     .input-wrapper:hover input[type="radio"] {
         background-color: var(--color-neutral);
-        &:before {
-            color: #e8ebf2;
-        }
+        
+    }
+    input[type="radio"]:checked:before, .input-wrapper:hover input[type="radio"]:before {
+        color: #e8ebf2;
     }
     input[type="radio"]:focus-visible {
         outline: 2px dashed var(--color-neutral);
-        &:before {
-            color: var(--color-neutral);
-        }
     }
+    input[type="radio"]:focus-visible:before{
+        color: var(--color-neutral);
+    } 
     input[type="radio"] + label {
         cursor: pointer;
         font-weight: 600;
@@ -412,124 +412,146 @@
 
     /* Has JS */
 
-    :global(html.js-enabled) section {
-        form {
-            position: absolute;
-            left: 50%;
-            translate: -50% -50%;
-            top: 300px;
-            width: 80%;
-            overflow: hidden;
-            height: 225px;
-            gap: 0;
-            min-width: 320px;
-        }
-        fieldset {
-            flex: 1;
-            opacity: 0;
-            text-align: center;
-        }
-        fieldset:first-child {
-            opacity: 1;
-        }
-        #formControl {
-            text-align: center;
-        }
-        .answers-wrapper {
-            justify-content: center;
-            gap: 0.5rem;
-            flex-direction: row;
-            .input-wrapper {
-                flex-direction: column;
-                text-align: center;
-                flex: 1;
-                input[type="radio"] {
-                    width: 44px;
-                    height: 44px;
-                }
-                input[type="radio"] + label {
-                    font-size: 13px;
-                }
-            }
-        }
-        @media (min-width: 500px) {
-            .answers-wrapper {
-                gap: 1rem;
-                flex-direction: row;
-                .input-wrapper {
-                    flex-direction: column;
-                    input[type="radio"] {
-                        width: 55px;
-                        height: 55px;
-                    }
-                    input[type="radio"] + label {
-                        font-size: 15px;
-                    }
-                }
-            }
-        }
-        @media (min-width: 850px) {
-            .answers-wrapper {
-                gap: 1rem;
-                flex-direction: row;
-                .input-wrapper {
-                    flex-direction: column;
-                    max-width: 140px;
-                    input[type="radio"] {
-                        width: 64px;
-                        height: 64px;
-                    }
-                    input[type="radio"] + label {
-                        font-size: 1rem;
-                    }
-                }
-            }
-        }
+    :global(html.js-enabled) section form {
+    position: absolute;
+    left: 50%;
+    translate: -50% -50%;
+    top: 300px;
+    width: 80%;
+    overflow: hidden;
+    height: 225px;
+    gap: 0;
+    min-width: 320px;
+}
+
+:global(html.js-enabled) section fieldset {
+    flex: 1;
+    opacity: 0;
+    text-align: center;
+}
+
+:global(html.js-enabled) section fieldset:first-child {
+    opacity: 1;
+}
+
+:global(html.js-enabled) section #formControl {
+    text-align: center;
+}
+
+:global(html.js-enabled) section .answers-wrapper {
+    justify-content: center;
+    gap: 0.5rem;
+    flex-direction: row;
+}
+
+:global(html.js-enabled) section .answers-wrapper .input-wrapper {
+    flex-direction: column;
+    text-align: center;
+    flex: 1;
+}
+
+:global(html.js-enabled) section .answers-wrapper .input-wrapper input[type="radio"] {
+    width: 44px;
+    height: 44px;
+}
+
+:global(html.js-enabled) section .answers-wrapper .input-wrapper input[type="radio"] + label {
+    font-size: 13px;
+}
+
+@media (min-width: 500px) {
+    :global(html.js-enabled) section .answers-wrapper {
+        gap: 1rem;
+        flex-direction: row;
+    }
+
+    :global(html.js-enabled) section .answers-wrapper .input-wrapper {
+        flex-direction: column;
+    }
+
+    :global(html.js-enabled) section .answers-wrapper .input-wrapper input[type="radio"] {
+        width: 55px;
+        height: 55px;
+    }
+
+    :global(html.js-enabled) section .answers-wrapper .input-wrapper input[type="radio"] + label {
+        font-size: 15px;
+    }
+}
+
+@media (min-width: 850px) {
+    :global(html.js-enabled) section .answers-wrapper {
+        gap: 1rem;
+        flex-direction: row;
+    }
+
+    :global(html.js-enabled) section .answers-wrapper .input-wrapper {
+        flex-direction: column;
+        max-width: 140px;
+    }
+
+    :global(html.js-enabled) section .answers-wrapper .input-wrapper input[type="radio"] {
+        width: 64px;
+        height: 64px;
+    }
+
+    :global(html.js-enabled) section .answers-wrapper .input-wrapper input[type="radio"] + label {
+        font-size: 1rem;
+    }
+}
+
+:global(.controls-container) {
+    top: 450px;
+    position: absolute;
+    translate: -50% -50%;
+    opacity: 1;
+    transition: .5s ease;
+    justify-content: center;
+    display: flex;
+    width: 100%;
+    max-width: 310px;
+    flex-wrap: wrap;
+    row-gap: 10px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    @starting-style {
         :global(.controls-container) {
-            top: 450px;
-            position: absolute;
-            translate: -50% -50%;
-            opacity: 1;
-            transition: .5s ease;
-            justify-content: center;
-            display: flex;
-            width: 100%;
-            max-width: 310px;
-            flex-wrap: wrap;
-            row-gap: 10px;
-            @media (prefers-reduced-motion: no-preference) {
-                @starting-style {
-                    opacity: 0;
-                    top: 550px;
-                }
-            }
-        }
-        :global(button.btn-nav) {
-            transition: 0.3s ease;
-            cursor: pointer;
-            padding: 8px 30px;
-            border-radius: 10px;
-            margin-left: 1rem;
-            font-size: 18px;
-            font-weight: bold;
-            border: 2px solid #54689c;
-        }
-        :global(button.btn-prev) {
-            background-color: #e8ebf2;
-            color: #54689c;
-            display: none;
-            &:hover{
-                background-color: #54689c;
-                color: #def0fc;
-            }
-        }
-        :global(button.btn-next) {
-            background-color: #54689c;
-            color: #def0fc;
-            &:hover{
-                background-color: #e8ebf2;
-                color: #54689c;
-            }
+            opacity: 0;
+            top: 550px;
         }
     }
+}
+
+:global(button.btn-nav) {
+    transition: 0.3s ease;
+    cursor: pointer;
+    padding: 8px 30px;
+    border-radius: 10px;
+    margin-left: 1rem;
+    font-size: 18px;
+    font-weight: bold;
+    border: 2px solid #54689c;
+}
+
+:global(button.btn-prev) {
+    background-color: #e8ebf2;
+    color: #54689c;
+    display: none;
+}
+
+:global(button.btn-prev):hover {
+    background-color: #54689c;
+    color: #def0fc;
+}
+
+:global(button.btn-next) {
+    background-color: #54689c;
+    color: #def0fc;
+}
+
+:global(button.btn-next):hover {
+    background-color: #e8ebf2;
+    color: #54689c;
+}
 </style>

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -281,7 +281,7 @@
         overflow-y: auto;
         padding-bottom: 3rem;
     }
-    @media (min-width: 750px) {
+    @media (min-width: 850px) {
         form {
             max-height: calc(100vh - 90px);
         }
@@ -364,7 +364,7 @@
         
     }
     input[type="radio"]:checked:before, .input-wrapper:hover input[type="radio"]:before {
-        color: #e8ebf2;
+        color: #e8ebf2 !important
     }
     input[type="radio"]:focus-visible {
         outline: 2px dashed var(--color-neutral);
@@ -417,7 +417,7 @@
     left: 50%;
     translate: -50% -50%;
     top: 300px;
-    width: 80%;
+    width: 85%;
     overflow: hidden;
     height: 225px;
     gap: 0;

--- a/src/routes/vragenlijst/+page.svelte
+++ b/src/routes/vragenlijst/+page.svelte
@@ -1,82 +1,271 @@
 <script>
     let { data } = $props();
+    import { onMount } from "svelte";
+    let count = $state(1);
     let vragenlijst = data.vragen;
-    let agreementsScales = [
-        { text: "Zeer mee oneens" },
-        { text: "Oneens" },
-        { text: "Neutraal" },
-        { text: "Eens" },
-        { text: "Zeer mee eens" },
-    ];
+    let agreementsScales = data.agreementsScales;
+    let jsEnabled = $state(false);
+    //When page is loaded or hard refreshed
+    onMount(() => {
+        //check for the html class that is acrtive when client side JS is enabled
+        jsEnabled = document.documentElement.classList.contains("js-enabled");
+        if (jsEnabled) {
+            document.querySelector('input[type="submit"]').tabIndex = -1
+            let formContainer = document.querySelector('#form-container')
+            let formEl = document.querySelector('#formEl');
+            // ADD CONTAINER FOR CONTROL BTNS
+            let controlBtnContainer = document.createElement("div");
+            controlBtnContainer.classList.add("controls-container");
+            if (formContainer) {
+                formContainer.appendChild(controlBtnContainer);
+            }
+
+            // add left
+            const prevBtn = document.createElement("button");
+            prevBtn.textContent = "Vorige";
+            prevBtn.tabIndex = -1;
+            prevBtn.classList.add("btn-prev");
+            prevBtn.classList.add("btn-nav");
+            prevBtn.addEventListener("click", (e) => prevQuestion(e));
+            if (controlBtnContainer) {
+                controlBtnContainer.appendChild(prevBtn);
+            }
+
+            //right
+            const nextBtn = document.createElement("button");
+            nextBtn.textContent = "Volgende";
+            nextBtn.tabIndex = -1;
+            nextBtn.classList.add("btn-next");
+            nextBtn.classList.add("btn-nav");
+            nextBtn.addEventListener("click", (e) => nextQuestion(e));
+            if (controlBtnContainer) {
+                controlBtnContainer.appendChild(nextBtn);
+            }
+
+            if (formEl) {
+                const firstChild = formEl.firstElementChild;
+                if (!firstChild) return;
+                function updateHeight() {
+                    const childHeight = firstChild.getBoundingClientRect().height;
+                    formEl.style.height = childHeight + "px";
+                    const questions = formEl.querySelectorAll("fieldset");
+                    // questions.forEach((fieldset) => {
+                    //     fieldset.style.opacity = "1";
+                    // });
+                    console.log(formEl.offsetHeight * ( count - 1))
+                    console.log('----')
+                    console.log(formEl.scrollTop)
+                    formEl.scrollTop = 0 + (formEl.offsetHeight * ( count - 1));
+                    document.querySelector('#formControl').style.paddingTop = (formEl.offsetHeight / 2 ) + "px";
+                    document.querySelector('#formControl').style.paddingBottom = (formEl.offsetHeight / 2 ) + "px";
+                }
+                updateHeight();
+                window.addEventListener("resize", updateHeight);
+            }
+            //tab control
+            const radios = document.querySelectorAll('#form-container form input');
+            const questions = formEl.querySelectorAll("fieldset");
+            radios.forEach((radio) => {
+                radio.addEventListener('keydown', (e) => {
+                    if (e.key === 'Tab') {
+
+                        // shift tab - prev question
+                        if (e.shiftKey) {
+                            prevQuestion(e);
+
+                        } else { //only tab pressed, next question it is
+                            
+                            nextQuestion(e);
+                            if(count == questions.length + 1){
+                                document.querySelector('input[type="submit"]').focus();
+                            }
+                        }
+                        const currentFieldset = formEl.querySelector(`fieldset:nth-child(${count})`);
+                        if(currentFieldset){
+                            let newFocus = currentFieldset.querySelector('input[type="radio"]:checked');
+                            if (!newFocus) {
+                                newFocus = currentFieldset.querySelector('.answers-wrapper .input-wrapper:first-child input[type="radio"]');
+                                newFocus.checked = true;
+                            }
+                            newFocus.focus();
+                        }
+                        console.log(count)
+                    }
+                });
+            });
+        }
+
+        // fix for when the body is active element and tab is being pressed
+        const q1g = document.querySelectorAll("[name='q-1']");
+        q1g.forEach((q1) => {
+            q1.addEventListener("focus", function(e) {
+                count = 1;
+                const form = document.querySelector('form');
+                form.scrollTop = 0;
+                document.querySelector('.controls-container .btn-prev').style.display = "none"
+                console.log(e.target);
+
+                const fieldset = e.target.closest('fieldset');
+                if (fieldset) {
+                    fieldset.style.opacity = 1;
+                    const questions = formEl.querySelectorAll("fieldset");
+                
+                        questions.forEach((fieldset) => {
+                            fieldset.style.opacity = "0";
+                            fieldset.classList.remove('animation--slide-in');
+                        });
+                        fieldset.style.opacity = 1;
+                        fieldset.classList.add('animation--slide-in');
+                    
+                }
+            });
+        });
+    });
+    //prev question button click
+    function prevQuestion(e) {
+        console.log(count);
+        console.log(e.type);
+        const questions = formEl.querySelectorAll("fieldset");
+        if(count == questions.length +1){
+            e.preventDefault();
+            document.querySelector('.controls-container .btn-next').style.display = "block"
+        }
+        if(count == 2){ // FIRST Q
+            // here no prevent default to get out of the form when shift tabbing
+            document.querySelector('.controls-container .btn-prev').style.display = "none"
+        }
+        if(count > 1 ){
+            e.preventDefault();
+            formEl.scrollTop -= formEl.offsetHeight;
+            count--;
+            const questions = formEl.querySelectorAll("fieldset");
+            const prevElement = formEl.querySelector(`fieldset:nth-child(${count})`);
+            if(prevElement){
+                questions.forEach((fieldset) => {
+                    fieldset.style.opacity = "0";
+                    fieldset.classList.remove('animation--slide-in');
+                });
+                prevElement.style.opacity = 1;
+                prevElement.classList.add('animation--slide-in');
+            }
+        }
+
+    }
+    //next question button click
+    function nextQuestion(e) {
+        document.querySelector('.controls-container .btn-prev').style.display = "block"
+        const questions = formEl.querySelectorAll("fieldset");
+        if(count == questions.length){
+            e.preventDefault();
+            document.querySelector('.controls-container .btn-next').style.display = "none"
+            questions.forEach((fieldset) => {
+                    fieldset.style.opacity = "0";
+                    fieldset.classList.remove('animation--slide-in');
+                });
+        }
+        if(count == questions.length + 1){
+            // so you can tab out of the form
+        }
+        if(count < questions.length + 1 ){
+            e.preventDefault();
+            formEl.scrollTop += formEl.offsetHeight;
+            count++;
+            const nextElement = formEl.querySelector(`fieldset:nth-child(${count})`);
+            if(nextElement){
+                questions.forEach((fieldset) => {
+                    fieldset.style.opacity = "0";
+                    fieldset.classList.remove('animation--slide-in');
+                });
+                nextElement.style.opacity = 1;
+                nextElement.classList.add('animation--slide-in');
+            }
+            
+        }
+        console.log(formEl.scrollTop);
+    }
+    
 </script>
 
-<section class="no-js">
+<section>
     <header class="page-header">
         <h1>Vragenlijst</h1>
         <p class="subtitle">Hoe heb je vandaag ervaren?</p>
     </header>
-    <form method="POST">
-        {#each vragenlijst as vraag, i}
-            <fieldset>
-                <legend>{vraag.vraag}</legend>
-                <div class="answers-wrapper">
-                    {#each agreementsScales as agreementsScale, j}
-                        <div class="input-wrapper">
-                            <input
-                                data-num={j + 1}
-                                type="radio"
-                                id="q-{i + 1}-a-{j + 1}"
-                                name="q-{i + 1}"
-                                value={agreementsScale.text}
-                                required={j === 0}
-                                oninvalid={j === 0
-                                    ? (e) => {
-                                          const radios =
-                                              document.querySelectorAll(
-                                                  'input[name="q-' +
-                                                      i +
-                                                      1 +
-                                                      "]",
+    <div id="form-container">
+        <form method="POST" id="formEl">
+            {#each vragenlijst as vraag, i}
+                <fieldset class={i == 0 ? "animation--slide-in" : ""}>
+                    <legend>{vraag.vraag}</legend>
+                    <div class="answers-wrapper">
+                        {#each agreementsScales as agreementsScale, j}
+                            <div class="input-wrapper">
+                                <input
+                                    data-num={j + 1}
+                                    type="radio"
+                                    id="q-{i + 1}-a-{j + 1}"
+                                    name="q-{i + 1}"
+                                    value={agreementsScale.text}
+                                    required={j === 0}
+                                    oninvalid={j === 0
+                                        ? (e) => {
+                                              const radios =
+                                                  document.querySelectorAll(
+                                                      'input[name="q-' +
+                                                          i +
+                                                          1 +
+                                                          "]",
+                                                  );
+                                              radios.forEach((r) =>
+                                                  r.setCustomValidity(
+                                                      "Kies een waarde",
+                                                  ),
                                               );
-                                          radios.forEach((r) =>
-                                              r.setCustomValidity(
-                                                  "Kies een waarde",
-                                              ),
-                                          );
-                                      }
-                                    : undefined}
-                                oninput={(e) => {
-                                    const radios = document.querySelectorAll(
-                                        'input[name="q-' + i + 1 + "]",
-                                    );
-                                    radios.forEach((r) =>
-                                        r.setCustomValidity(""),
-                                    );
-                                }}
-                            />
-                            <!-- Custom bericht als veld niet ingevuld is-->
-                            <!-- https://www.w3schools.com/jsref/event_oninvalid.asp -->
-                            <!-- https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity -->
-                            <label for="q-{i + 1}-a-{j + 1}"
-                                >{agreementsScale.text}</label
-                            >
-                        </div>
-                    {/each}
-                </div>
-            </fieldset>
-        {/each}
+                                          }
+                                        : undefined}
+                                    oninput={(e) => {
+                                        const radios =
+                                            document.querySelectorAll(
+                                                'input[name="q-' + i + 1 + "]",
+                                            );
+                                        radios.forEach((r) =>
+                                            r.setCustomValidity(""),
+                                        );
+                                    }}
+                                />
+                                <!-- Custom bericht als veld niet ingevuld is-->
+                                <!-- https://www.w3schools.com/jsref/event_oninvalid.asp -->
+                                <!-- https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity -->
+                                <label for="q-{i + 1}-a-{j + 1}"
+                                    >{agreementsScale.text}</label
+                                >
+                            </div>
+                        {/each}
+                    </div>
+                </fieldset>
+            {/each}
 
-        <div id="formControl">
-            <input type="submit" value="Submit" />
-        </div>
-    </form>
+            <div id="formControl">
+                <input type="submit" value="Verstuur vragenlijst" />
+            </div>
+        </form>
+    </div>
 </section>
 
 <style>
+    button {
+        opacity: 0;
+        transform: translateY(5px);
+        transition:
+            opacity 1s,
+            transform 1s;
+    }
     section {
         display: flex;
         flex-direction: column;
         align-items: center;
+    }
+    legend {
+        height: 72px;
     }
     form {
         width: 100%;
@@ -88,18 +277,31 @@
         overflow-y: auto;
         padding-bottom: 3rem;
     }
-    @media (min-width: 750px){
-        form{
-        max-height: calc(100vh - 90px);
+    @media (min-width: 750px) {
+        form {
+            max-height: calc(100vh - 90px);
+        }
+    }
+    @keyframes slide-in{
+        0%{
+            translate: 0 100px;
+        }
+        100%{
+            translate: 0 0;
         }
     }
     fieldset {
-padding: 0 1rem
-16px
-;
+        padding: 0.5rem 1rem 0.5rem;
         border: none;
         margin: 0;
+        transition: 1.25s ease;
+        
     }
+    :global(.animation--slide-in){
+            legend{
+                animation: .5s slide-in ease-in;
+            }
+        }
 
     legend {
         font-weight: 600;
@@ -150,34 +352,37 @@ padding: 0 1rem
             transition: 0.3s ease-in;
         }
     }
-    input[type="radio"]:checked,input[type="radio"]:focus-visible, .input-wrapper:hover input[type="radio"]{
-        width: 64px;
-        height: 64px;
-        border-radius: 10px;
+    input[type="radio"]:checked,
+    .input-wrapper:hover input[type="radio"] {
         background-color: var(--color-neutral);
-        appearance: none;
-        border: 2px solid var(--color-neutral);
         &:before {
             color: #e8ebf2;
         }
     }
-    input[type="radio"] + label{
+    input[type="radio"]:focus-visible {
+        outline: 2px dashed var(--color-neutral);
+        &:before {
+            color: var(--color-neutral);
+        }
+    }
+    input[type="radio"] + label {
         cursor: pointer;
         font-weight: 600;
         color: var(--color-neutral);
     }
-    input[type="submit"]{
+    input[type="submit"] {
         cursor: pointer;
         padding: 8px 30px;
-        background-color: #54689C;
-        color: #DEF0FC;
-        border: 2px solid #54689C;
+        background-color: #54689c;
+        color: #def0fc;
+        border: 2px solid #54689c;
         border-radius: 10px;
         margin-left: 1rem;
         font-size: 18px;
         font-weight: bold;
     }
-    input[type="submit"]:hover,input[type="submit"]:focus-visible{
+    input[type="submit"]:hover,
+    input[type="submit"]:focus-visible {
         background-color: #e8ebf2;
         color: var(--color-neutral);
     }
@@ -186,6 +391,9 @@ padding: 0 1rem
         gap: 1rem;
         flex-direction: column;
         margin-top: 1rem;
+        background: white;
+        z-index: 3;
+        position: relative;
     }
     .input-wrapper {
         display: flex;
@@ -193,5 +401,126 @@ padding: 0 1rem
         gap: 1rem;
         width: fit-content;
         cursor: pointer;
+    }
+
+    /* Has JS */
+
+    :global(html.js-enabled) section {
+        form {
+            position: absolute;
+            left: 50%;
+            translate: -50% -50%;
+            top: 300px;
+            width: 80%;
+            overflow: hidden;
+            height: 225px;
+            gap: 0;
+            min-width: 320px;
+        }
+        fieldset {
+            flex: 1;
+            opacity: 0;
+            text-align: center;
+        }
+        fieldset:first-child {
+            opacity: 1;
+        }
+        #formControl {
+            text-align: center;
+        }
+        .answers-wrapper {
+            justify-content: center;
+            gap: 0.5rem;
+            flex-direction: row;
+            .input-wrapper {
+                flex-direction: column;
+                text-align: center;
+                flex: 1;
+                input[type="radio"] {
+                    width: 44px;
+                    height: 44px;
+                }
+                input[type="radio"] + label {
+                    font-size: 13px;
+                }
+            }
+        }
+        @media (min-width: 500px) {
+            .answers-wrapper {
+                gap: 1rem;
+                flex-direction: row;
+                .input-wrapper {
+                    flex-direction: column;
+                    input[type="radio"] {
+                        width: 55px;
+                        height: 55px;
+                    }
+                    input[type="radio"] + label {
+                        font-size: 15px;
+                    }
+                }
+            }
+        }
+        @media (min-width: 850px) {
+            .answers-wrapper {
+                gap: 1rem;
+                flex-direction: row;
+                .input-wrapper {
+                    flex-direction: column;
+                    max-width: 140px;
+                    input[type="radio"] {
+                        width: 64px;
+                        height: 64px;
+                    }
+                    input[type="radio"] + label {
+                        font-size: 1rem;
+                    }
+                }
+            }
+        }
+        :global(.controls-container) {
+            top: 450px;
+            position: absolute;
+            translate: -50% -50%;
+            opacity: 1;
+            transition: 2s ease;
+            justify-content: center;
+            display: flex;
+            width: 100%;
+            max-width: 310px;
+            flex-wrap: wrap;
+            row-gap: 10px;
+            @starting-style {
+                opacity: 0;
+                top: 550px;
+            }
+        }
+        :global(button.btn-nav) {
+            transition: 0.3s ease;
+            cursor: pointer;
+            padding: 8px 30px;
+            border-radius: 10px;
+            margin-left: 1rem;
+            font-size: 18px;
+            font-weight: bold;
+            border: 2px solid #54689c;
+        }
+        :global(button.btn-prev) {
+            background-color: #e8ebf2;
+            color: #54689c;
+            display: none;
+            &:hover{
+                background-color: #54689c;
+                color: #def0fc;
+            }
+        }
+        :global(button.btn-next) {
+            background-color: #54689c;
+            color: #def0fc;
+            &:hover{
+                background-color: #e8ebf2;
+                color: #54689c;
+            }
+        }
     }
 </style>

--- a/static/css/globals.css
+++ b/static/css/globals.css
@@ -6,7 +6,7 @@
 
     /* padding-right: 1px; */
 }
-@media (min-width: 750px){
+@media (min-width: 850px){
     #container{
         display: grid;
         grid-template-columns: 320px 1fr;

--- a/static/stylesheet.css
+++ b/static/stylesheet.css
@@ -1,6 +1,6 @@
 :root {
   /* Kleuren met fallback */
-  --primary-color-light: rgb(41, 158, 222); /* fallback */
+  --primary-color-light: rgb(41, 158, 222); /* fa llback */
   --primary-color-light: hsl(204, 82%, 41%);
 
   --primary-color-dark: rgb(8, 63, 119); /* fallback */
@@ -12,6 +12,23 @@
   --color-white: rgb(255, 255, 255); /* fallback */
   --color-white: hsl(0, 0%, 100%);
 
+  /* Neutral colors */
+
+  /* RGB fallbacks first */
+  --color-neutral-darker: rgb(0, 0, 0);
+  --color-neutral-dark: rgb(31, 36, 50);
+  --color-neutral: rgb(84, 104, 156);
+  --color-neutral-light: rgb(170, 176, 194);
+  --color-neutral-lighter: rgb(229, 232, 242);
+
+  /* Overwrite with HSL if supported */
+  --color-neutral-darker: hsl(0, 0%, 0%);
+  --color-neutral-dark: hsl(230, 21%, 14%);
+  --color-neutral: hsl(223, 30%, 47%);
+  --color-neutral-light: hsl(224, 14%, 72%);
+  --color-neutral-lighter: hsl(223, 40%, 91%);
+
+
   /* Fonts */
   --font-regular: "Inter", sans-serif;
   --font-medium: "Inter Medium", "Inter", sans-serif;
@@ -22,6 +39,6 @@
   --text-size-sm: clamp(0.875rem, 1.75vw, 14px);
   --text-size-md: clamp(1rem, 2vw, 16px);
   --text-size-lg: clamp(1.125rem, 2.25vw, 18px);
-  --text-size-xl: clamp(1.4rem, 2.5vw, 20px);
+  --text-size-xl: clamp(1.4rem, 2.5vw, 30px);
 }
 


### PR DESCRIPTION
## What does this change?

Resolves issue #71

I added vragenlijst HTML/CSS JS (PE). I made sure that if JS is enabled, the view looks like the designed section. The vragenlijst consists of fieldsets with 5 radiobuttons for each question in the `vraag` table in Directus.

When the form is submitted, the vragenlijst with the user's answers will be posted to today's treatment. If there is no treatment today, make a new treatment and copy the last available bingocard if today has no bingocard yet.

Also added the neutral colors to the stylesheet. Those were in the design but not in code yet.

## How Has This Been Tested?

- [ ] [User test]()
- [x] [Accessibility test]()
https://github.com/fdnd-agency/herstelkompas/issues/71#issuecomment-3427488973

### Screenreader test

https://github.com/user-attachments/assets/075561b5-c9f2-4104-a972-7a21563cdcbd

- [x] [Performance test]()
https://github.com/fdnd-agency/herstelkompas/issues/71#issuecomment-3427488973
- [x] [Responsive Design test]()
https://github.com/fdnd-agency/herstelkompas/issues/71#issuecomment-3431184368
- [x] [Device test]()
https://github.com/fdnd-agency/herstelkompas/issues/71#issuecomment-3431184368
Need to test on an old device
- [x] [Browser test]()
https://github.com/fdnd-agency/herstelkompas/issues/71#issuecomment-3431178571
https://github.com/fdnd-agency/herstelkompas/issues/71#issuecomment-3431184368

## Video


https://github.com/user-attachments/assets/3c0a2067-69c7-4ccd-9bd2-d26b16bc17be




## How to review


### Locally

You can view the page on this branch, make sure to install the `@directus/sdk` package by running `npm i`

### Test server

You can also visit the test server for the branch on:
https://bespoke-chebakia-0ec431.netlify.app/vragenlijst



@Keremttc  can you review if this is okay?